### PR TITLE
Switch DDAI endpoints to ddai.space

### DIFF
--- a/internal/captcha/captcha.go
+++ b/internal/captcha/captcha.go
@@ -32,7 +32,7 @@ func NewCaptchaServices() *CaptchaServices {
 	config := LoadConfig()
 	return &CaptchaServices{
 		sitekey:           "0x4AAAAAABdw7Ezbqw4v6Kr1",
-		pageUrl:           "https://app.ddai.network/",
+		pageUrl:           "https://app.ddai.space/",
 		cfSolved:          config.CaptchaServices.UrlPrivate + "/turnstiler",
 		antiCaptchaApiUrl: "https://api.anti-captcha.com",
 	}
@@ -74,7 +74,7 @@ func (cs *CaptchaServices) solvedPrivate(currentNum, total int) (string, error) 
 	utils.LogMessage(currentNum, total, "Trying to solved captcha cloudflare...", "process")
 
 	data := map[string]interface{}{
-		"url":     "https://app.ddai.network/",
+		"url":     "https://app.ddai.space/",
 		"siteKey": "0x4AAAAAABdw7Ezbqw4v6Kr1",
 		"mode":    "turnstile-min",
 	}

--- a/internal/ddai/referral.go
+++ b/internal/ddai/referral.go
@@ -213,7 +213,7 @@ func (m *ddaiReferral) registerAccount(email string, username string, password s
 		"Content-Type": "application/json",
 	}
 
-	body, err := m.httpClient.MakeRequestWithBody("POST", "https://auth.ddai.network/register", jsonData, headers)
+	body, err := m.httpClient.MakeRequestWithBody("POST", "https://auth.ddai.space/register", jsonData, headers)
 	if err != nil {
 		return fmt.Errorf("registration request failed: %v", err)
 	}
@@ -253,7 +253,7 @@ func (m *ddaiReferral) loginAccount(username string, password string, captcha st
 		"Content-Type": "application/json",
 	}
 
-	body, err := m.httpClient.MakeRequestWithBody("POST", "https://auth.ddai.network/login", jsonData, headers)
+	body, err := m.httpClient.MakeRequestWithBody("POST", "https://auth.ddai.space/login", jsonData, headers)
 	if err != nil {
 		return "", fmt.Errorf("login request failed: %v", err)
 	}
@@ -284,7 +284,7 @@ func (m *ddaiReferral) getUserTask(accessToken string) ([]map[string]string, err
 		"Authorization": "Bearer " + accessToken,
 	}
 
-	body, err := m.httpClient.MakeRequestWithBody("GET", "https://auth.ddai.network/missions", nil, headers)
+	body, err := m.httpClient.MakeRequestWithBody("GET", "https://auth.ddai.space/missions", nil, headers)
 	if err != nil {
 		return nil, fmt.Errorf("get tasks request failed: %v", err)
 	}
@@ -318,7 +318,7 @@ func (m *ddaiReferral) getUserTask(accessToken string) ([]map[string]string, err
 func (m *ddaiReferral) claimTask(accessToken string, task map[string]string) error {
 	utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Claiming task: %s (ID: %s)", task["name"], task["id"]), "process")
 
-	url := fmt.Sprintf("https://auth.ddai.network/missions/claim/%s", task["id"])
+	url := fmt.Sprintf("https://auth.ddai.space/missions/claim/%s", task["id"])
 
 	headers := map[string]string{
 		"Content-Type":  "application/json",

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Automated tool for DDAI Depin
 
 ## Requirements
 
-- **DDAI Account**: [Register on DDAI Network](https://app.ddai.network/register?ref=r9zs0fHw)
+- **DDAI Account**: [Register on DDAI Network](https://app.ddai.space/register?ref=r9zs0fHw)
 - **Proxy**: Optional, but recommended for multi-account management
 - **Captcha Service**: Configure in `config.json` (Private/2Captcha/AntiCaptcha)
 


### PR DESCRIPTION
## Summary
- update README to use `ddai.space`
- change API endpoints from `ddai.network` to `ddai.space`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_686dfd8791108323a2ec637d471b2f37