### PR TITLE
Implement auto bot mode

### DIFF
--- a/internal/ddai/runbot.go
+++ b/internal/ddai/runbot.go
@@ -1,1 +1,183 @@
 package ddai
+
+import (
+	"ddai-bot/internal/captcha"
+	"ddai-bot/internal/utils"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type ddaiRunBot struct {
+	proxy      string
+	email      string
+	password   string
+	currentNum int
+	total      int
+	captcha    *captcha.CaptchaServices
+	httpClient *HTTPClient
+}
+
+func NewDdaiRunBot(email, password, proxy string, currentNum, total int) *ddaiRunBot {
+	return &ddaiRunBot{
+		proxy:      proxy,
+		email:      email,
+		password:   password,
+		currentNum: currentNum,
+		total:      total,
+		captcha:    captcha.NewCaptchaServices(),
+		httpClient: NewHTTPClient(proxy, currentNum, total),
+	}
+}
+
+func (m *ddaiRunBot) SingleProses() error {
+	for attempt := 1; attempt <= retryCount; attempt++ {
+		utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Attempt %d/%d", attempt, retryCount), "process")
+
+		token, err := m.captcha.SolveCaptcha(m.currentNum, m.total)
+		if err != nil {
+			utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Failed to solve captcha: %v", err), "error")
+			continue
+		}
+
+		accessToken, err := m.loginAccount(m.email, m.password, token)
+		if err != nil {
+			utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("%v", err), "warning")
+			time.Sleep(retryDelay)
+			continue
+		}
+
+		taskList, err := m.getUserTask(accessToken)
+		if err != nil {
+			utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Failed to get tasks: %v", err), "warning")
+			time.Sleep(retryDelay)
+			continue
+		}
+
+		allTasksSuccess := true
+		for _, task := range taskList {
+			if err := m.claimTask(accessToken, task); err != nil {
+				utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Failed to claim task %s: %v", task["name"], err), "warning")
+				allTasksSuccess = false
+			}
+			time.Sleep(1 * time.Second)
+		}
+
+		anyTaskSuccess := len(taskList) > 0 && (allTasksSuccess || !allTasksSuccess)
+		utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Tasks found: %d, Tasks claimed: %v", len(taskList), anyTaskSuccess), "info")
+		return nil
+	}
+
+	return fmt.Errorf("failed after %d attempts", retryCount)
+}
+
+func (m *ddaiRunBot) loginAccount(username string, password string, captcha string) (string, error) {
+	utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Logging in with username: %s", username), "process")
+	payload := map[string]string{
+		"username":     username,
+		"password":     password,
+		"captchaToken": captcha,
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal payload: %v", err)
+	}
+
+	headers := map[string]string{
+		"Content-Type": "application/json",
+	}
+
+	body, err := m.httpClient.MakeRequestWithBody("POST", "https://auth.ddai.space/login", jsonData, headers)
+	if err != nil {
+		return "", fmt.Errorf("login request failed: %v", err)
+	}
+
+	var response LoginResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("failed to decode response: %v (body: %s)", err, string(body))
+	}
+
+	if response.Status == "success" {
+		utils.LogMessage(m.currentNum, m.total, "Successfully logged in", "success")
+		return response.Data.AccessToken, nil
+	}
+
+	errorMsg := response.Error["message"]
+	if errorMsg == nil {
+		errorMsg = response.Error
+	}
+	return "", fmt.Errorf("login failed: %v", errorMsg)
+}
+
+func (m *ddaiRunBot) getUserTask(accessToken string) ([]map[string]string, error) {
+	utils.LogMessage(m.currentNum, m.total, "Fetching user tasks...", "process")
+
+	headers := map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "Bearer " + accessToken,
+	}
+
+	body, err := m.httpClient.MakeRequestWithBody("GET", "https://auth.ddai.space/missions", nil, headers)
+	if err != nil {
+		return nil, fmt.Errorf("get tasks request failed: %v", err)
+	}
+
+	var response MissionsResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %v (body: %s)", err, string(body))
+	}
+
+	utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Found %d missions", len(response.Data.Missions)), "info")
+
+	var tasks []map[string]string
+	for _, task := range response.Data.Missions {
+		if task.Status == "PENDING" || task.Status == "idle" || task.Status == "pending" {
+			if containsIgnoreCase(task.Title, "invite") {
+				continue
+			}
+
+			taskInfo := map[string]string{
+				"id":   task.ID,
+				"name": task.Title,
+			}
+			tasks = append(tasks, taskInfo)
+		}
+	}
+	return tasks, nil
+}
+
+func (m *ddaiRunBot) claimTask(accessToken string, task map[string]string) error {
+	utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Claiming task: %s (ID: %s)", task["name"], task["id"]), "process")
+
+	url := fmt.Sprintf("https://auth.ddai.space/missions/claim/%s", task["id"])
+	headers := map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "Bearer " + accessToken,
+	}
+
+	body, err := m.httpClient.MakeRequestWithBody("POST", url, nil, headers)
+	if err != nil {
+		return fmt.Errorf("claim task request failed: %v", err)
+	}
+
+	var result ClaimResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Raw response: %s", string(body)), "warning")
+		return fmt.Errorf("failed to decode response: %v", err)
+	}
+
+	if result.Status != "success" {
+		errorMsg := "unknown error"
+		if result.Error != nil {
+			if msg, ok := result.Error["message"]; ok {
+				errorMsg = fmt.Sprintf("%v", msg)
+			}
+		}
+		utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Claim failed: %s", errorMsg), "warning")
+		return fmt.Errorf("claim task failed: %s", errorMsg)
+	}
+
+	utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Successfully claimed task: %s with rewards: %d requests", task["name"], result.Data.Rewards.Requests), "success")
+	return nil
+}

--- a/internal/menu/menu.go
+++ b/internal/menu/menu.go
@@ -35,7 +35,7 @@ func (m *MenuHandler) ShowMainMenu(version string) {
 			m.RunReferralProgram()
 			m.showBanner(version)
 		case "2":
-			//m.RunAutoBot()
+			m.RunAutoBot()
 			m.showBanner(version)
 		case "3":
 			m.EditConfig()

--- a/internal/menu/runbot.go
+++ b/internal/menu/runbot.go
@@ -1,1 +1,100 @@
 package menu
+
+import (
+	"bufio"
+	"ddai-bot/internal/ddai"
+	"ddai-bot/internal/proxy"
+	"ddai-bot/internal/utils"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+)
+
+type account struct {
+	email    string
+	password string
+}
+
+func (m *MenuHandler) loadRunAccounts() ([]account, error) {
+	file, err := os.Open("runaccounts.txt")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var accounts []account
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		accounts = append(accounts, account{email: parts[0], password: parts[1]})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
+func (m *MenuHandler) runConcurrent(accounts []account) {
+	proxy.LoadProxies()
+	total := len(accounts)
+	var wg sync.WaitGroup
+	for idx, acc := range accounts {
+		wg.Add(1)
+		go func(i int, a account) {
+			defer wg.Done()
+			prx, _ := proxy.GetRandomProxy(i+1, total)
+			bot := ddai.NewDdaiRunBot(a.email, a.password, prx, i+1, total)
+			if err := bot.SingleProses(); err != nil {
+				utils.LogMessage(i+1, total, fmt.Sprintf("Run failed: %v", err), "warning")
+			}
+		}(idx, acc)
+	}
+	wg.Wait()
+}
+
+func (m *MenuHandler) runQueue(accounts []account) {
+	proxy.LoadProxies()
+	total := len(accounts)
+	for idx, acc := range accounts {
+		prx, _ := proxy.GetRandomProxy(idx+1, total)
+		bot := ddai.NewDdaiRunBot(acc.email, acc.password, prx, idx+1, total)
+		if err := bot.SingleProses(); err != nil {
+			utils.LogMessage(idx+1, total, fmt.Sprintf("Run failed: %v", err), "warning")
+		}
+	}
+}
+
+func (m *MenuHandler) RunAutoBot() {
+	accounts, err := m.loadRunAccounts()
+	if err != nil {
+		utils.LogMessage(0, 0, "Failed to load runaccounts.txt: "+err.Error(), "error")
+		m.waitForEnter()
+		return
+	}
+	if len(accounts) == 0 {
+		utils.LogMessage(0, 0, "No accounts found in runaccounts.txt", "error")
+		m.waitForEnter()
+		return
+	}
+
+	choice := m.showBotModeMenu()
+	switch choice {
+	case "1":
+		m.runConcurrent(accounts)
+	case "2":
+		m.runQueue(accounts)
+	default:
+		return
+	}
+
+	utils.LogMessage(0, 0, "Finished running accounts", "success")
+	m.waitForEnter()
+}


### PR DESCRIPTION
## Summary
- add logic to read `runaccounts.txt` and run tasks for those accounts
- implement bot runner in ddai package for login and task claiming
- call new auto bot flow from the menu

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_686f01dc35cc8323bb3e71be20cfa74a