### PR TITLE
Fix login payload to use email

### DIFF
--- a/internal/ddai/referral.go
+++ b/internal/ddai/referral.go
@@ -156,7 +156,7 @@ func (m *ddaiReferral) SingleProses() error {
 			continue
 		}
 
-		accessToken, err := m.loginAccount(username, password, token)
+		accessToken, err := m.loginAccount(email, password, token)
 		if err != nil {
 			utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("%v", err), "warning")
 			return err
@@ -236,10 +236,10 @@ func (m *ddaiReferral) registerAccount(email string, username string, password s
 	return fmt.Errorf("registration failed: %v", errorMsg)
 }
 
-func (m *ddaiReferral) loginAccount(username string, password string, captcha string) (string, error) {
-	utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Logging in with username: %s", username), "process")
+func (m *ddaiReferral) loginAccount(email string, password string, captcha string) (string, error) {
+	utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Logging in with email: %s", email), "process")
 	payload := map[string]string{
-		"username":     username,
+		"email":        email,
 		"password":     password,
 		"captchaToken": captcha,
 	}

--- a/internal/ddai/runbot.go
+++ b/internal/ddai/runbot.go
@@ -47,9 +47,9 @@ func (m *ddaiRunBot) SingleProses() error {
 			continue
 		}
 
-
 		if err := m.modelResponse(accessToken); err != nil {
 			utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Model response failed: %v", err), "warning")
+		}
 
 		taskList, err := m.getUserTask(accessToken)
 		if err != nil {
@@ -58,7 +58,6 @@ func (m *ddaiRunBot) SingleProses() error {
 			time.Sleep(retryDelay)
 			continue
 		}
-
 
 		if err := m.onchainTrigger(accessToken); err != nil {
 			utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Onchain trigger failed: %v", err), "warning")
@@ -86,10 +85,10 @@ func (m *ddaiRunBot) SingleProses() error {
 	return fmt.Errorf("failed after %d attempts", retryCount)
 }
 
-func (m *ddaiRunBot) loginAccount(username string, password string, captcha string) (string, error) {
-	utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Logging in with username: %s", username), "process")
+func (m *ddaiRunBot) loginAccount(email string, password string, captcha string) (string, error) {
+	utils.LogMessage(m.currentNum, m.total, fmt.Sprintf("Logging in with email: %s", email), "process")
 	payload := map[string]string{
-		"username":     username,
+		"email":        email,
 		"password":     password,
 		"captchaToken": captcha,
 	}
@@ -197,7 +196,6 @@ func (m *ddaiRunBot) claimTask(accessToken string, task map[string]string) error
 	return nil
 }
 
-
 type genericResponse struct {
 	Status string                 `json:"status"`
 	Error  map[string]interface{} `json:"error"`
@@ -258,4 +256,3 @@ func (m *ddaiRunBot) onchainTrigger(accessToken string) error {
 
 	return nil
 }
-


### PR DESCRIPTION
## Summary
- send `email` rather than `username` when logging in so authentication succeeds
- update referral workflow to pass email into `loginAccount`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_686f0afa76208323ab8535a462c9edb1